### PR TITLE
chore: 移除 VSCode 设置中的自定义颜色配置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -41,11 +41,6 @@
   // "typescript.inlayHints.propertyDeclarationTypes.enabled": true,
   "typescript.inlayHints.parameterTypes.enabled": true,
   // "typescript.inlayHints.functionLikeReturnTypes.enabled": true,
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#0E3140",
-    "titleBar.activeBackground": "#14455A",
-    "titleBar.activeForeground": "#F8FCFD"
-  },
   "cSpell.words": [
     "allowtransparency",
     "autoplay",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,19 +1,9 @@
-import path from 'node:path'
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
 import vscode from '@tomjs/vite-plugin-vscode'
 import react from '@vitejs/plugin-react-swc'
 import { defineConfig } from 'vite'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
 import pkg from './package.json'
-
-const dir =
-  typeof __dirname === 'string'
-    ? __dirname
-    : dirname(fileURLToPath(import.meta.url))
-
-const resolvePath = (...paths: string[]) => path.resolve(dir, ...paths)
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
@@ -26,7 +16,7 @@ export default defineConfig(() => {
       react(),
       vscode({
         extension: {
-          entry: resolvePath('./src/extension/index.ts'),
+          entry: './src/extension/index.ts',
           platform: 'node',
           target: 'node18',
           sourcemap: true,


### PR DESCRIPTION
移除配置文件中的自定义颜色设置